### PR TITLE
Fix link to the vim mapping tutorial, missing the close-parens

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ nmap <your_key_combo> <Plug>SetTmuxVars
 ```
 
 More info about the `<Plug>` and other mapping syntax can be found
-[here](http://vim.wikia.com/wiki/Mapping_keys_in_Vim_-_Tutorial_(Part_3)).
+[here](http://vim.wikia.com/wiki/Mapping_keys_in_Vim_-_Tutorial_(Part_3\) ).


### PR DESCRIPTION
The readme has a link to part 3 of a vim tutorial, but the close-parens needed to be escaped. Fixed :)
