### PR TITLE
system("tmux show-buffer") can be a problem.

### DIFF
--- a/plugin/tslime.vim
+++ b/plugin/tslime.vim
@@ -15,7 +15,7 @@ function! Send_to_Tmux(text)
     call <SID>Tmux_Vars()
   end
 
-  let oldbuffer = system("tmux show-buffer")
+  let oldbuffer = system(shellescape("tmux show-buffer"))
   call <SID>set_tmux_buffer(a:text)
   call system("tmux paste-buffer -t " . s:tmux_target())
   call <SID>set_tmux_buffer(oldbuffer)


### PR DESCRIPTION
 shell-escape "tmux show-buffer" because that broke the plugin on my Gentoo box.

Among other things, sin of all sins, that prevented me from using turbux.vim .

This change has been tested on Gentoo Linux / vim 7.3 / tmux 1.6 and OSX / vim 7.3 / tmux 1.6.
