### PR TITLE
handle larger blocks of text (via file), return cursor to original position

### DIFF
--- a/plugin/tslime.vim
+++ b/plugin/tslime.vim
@@ -19,6 +19,7 @@ function! Send_to_Tmux(text)
   call <SID>set_tmux_buffer(a:text)
   call system("tmux paste-buffer -t " . s:tmux_target())
   call <SID>set_tmux_buffer(oldbuffer)
+  normal ``
 endfunction
 
 function! s:tmux_target()
@@ -97,8 +98,8 @@ function! s:Tmux_Vars()
   endif
 endfunction
 
-vmap <unique> <Plug>SendSelectionToTmux "ry :call Send_to_Tmux(@r)<CR>
-nmap <unique> <Plug>NormalModeSendToTmux vip <Plug>SendSelectionToTmux
+vmap <unique> <Plug>SendSelectionToTmux m`"ry :call Send_to_Tmux(@r)<CR>
+nmap <unique> <Plug>NormalModeSendToTmux m`vip"ry :call Send_to_Tmux(@r)<CR>
 
 nmap <unique> <Plug>SetTmuxVars :call <SID>Tmux_Vars()<CR>
 


### PR DESCRIPTION
First commit fixes the issue with sending large amounts of text, which is described in another fork, here:
https://github.com/kikijump/tslime.vim/issues/2

Second commit makes sure tslime leaves the cursor where it found it (by adding current position to jump list at the beginning and jumping back when done).
