### PR TITLE
Always return cursor to initial position after sending text.

### DIFF
--- a/plugin/tslime.vim
+++ b/plugin/tslime.vim
@@ -19,6 +19,7 @@ function! Send_to_Tmux(text)
   call <SID>set_tmux_buffer(a:text)
   call system("tmux paste-buffer -t " . s:tmux_target())
   call <SID>set_tmux_buffer(oldbuffer)
+  normal ``
 endfunction
 
 function! s:tmux_target()
@@ -98,8 +99,8 @@ function! s:Tmux_Vars()
   endif
 endfunction
 
-vmap <unique> <Plug>SendSelectionToTmux "ry :call Send_to_Tmux(@r)<CR>
-nmap <unique> <Plug>NormalModeSendToTmux vip <Plug>SendSelectionToTmux
+vmap <unique> <Plug>SendSelectionToTmux m`"ry :call Send_to_Tmux(@r)<CR>
+nmap <unique> <Plug>NormalModeSendToTmux m`vip"ry :call Send_to_Tmux(@r)<CR>
 
 nmap <unique> <Plug>SetTmuxVars :call <SID>Tmux_Vars()<CR>
 


### PR DESCRIPTION
Adds the initial position to the jump list before sending text, then jumps back to it when done. Previous behaviour had the cursor end up at the top of the block/selection.