### PR TITLE
Avoid limit of tmux set buffer

### DIFF
--- a/plugin/tslime.vim
+++ b/plugin/tslime.vim
@@ -26,9 +26,7 @@ function! s:tmux_target()
 endfunction
 
 function! s:set_tmux_buffer(text)
-  call writefile(split(a:text, "\<NL>"), '/tmp/vim-tslime-buffer')
-  call system("tmux load-buffer /tmp/vim-tslime-buffer")
-  call writefile([], '/tmp/vim-tslime-buffer') " file truncated but previous contents NOT SECURELY DELETED
+  call system("echo '" . substitute(a:text, "'", "'\\\\''", 'g') . "' | tmux load-buffer -" )
 endfunction
 
 function! SendToTmux(text)


### PR DESCRIPTION
This fixes the issue with sending large amounts of text (>2036 chars), which is described in another fork, here: https://github.com/kikijump/tslime.vim/issues/2
