### PR TITLE
Don't let echo add an extra newline when doing tmux load-buffer.

### DIFF
--- a/plugin/tslime.vim
+++ b/plugin/tslime.vim
@@ -26,7 +26,7 @@ function! s:tmux_target()
 endfunction
 
 function! s:set_tmux_buffer(text)
-  call system("echo '" . substitute(a:text, "'", "'\\\\''", 'g') . "' | tmux load-buffer -" )
+  call system("echo -n '" . substitute(a:text, "'", "'\\\\''", 'g') . "' | tmux load-buffer -" )
 endfunction
 
 function! SendToTmux(text)


### PR DESCRIPTION
Fixes a regression introduced when switching load-buffer instead of set-buffer.
