### PR TITLE
Add setting to use the current session/window

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@ account.
 branch. The version available in that branch isn't aware of panes so it
 will paste to pane 0 of the window.
 
+Settings
+--------
+
+You can tell tslime.vim to use the current session and current window, this let's you 
+avoid specifying this on every upstart of vim.
+
+let g:tslime_always_current_session = 1
+let g:tslime_always_current_window = 1
+
+These are disabled by default, meaning you will have the ability to choose from every 
+session/window/pane combination.
+
 Setting Keybindings
 -------------------
 

--- a/plugin/tslime.vim
+++ b/plugin/tslime.vim
@@ -64,12 +64,25 @@ function! s:TmuxSessions()
   return sessions
 endfunction
 
+function! s:ActiveTarget()
+  return split(system('tmux list-panes -F "active=#{pane_active} #{session_name},#{window_index},#{pane_index}" | grep "active=1" | sed -e "s/.*\s//" -e "s/,/\n/g"'), '\n')
+endfunction
+
 function! s:TmuxWindows()
   return system('tmux list-windows -t "' . g:tslime['session'] . '" | grep -e "^\w:" | sed -e "s/\s*([0-9].*//g"')
 endfunction
 
 function! s:TmuxPanes()
-  return system('tmux list-panes -t "' . g:tslime['session'] . '":' . g:tslime['window'] . " | sed -e 's/:.*$//'")
+  let all_panes = split(system('tmux list-panes -t "' . g:tslime['session'] . '":' . g:tslime['window'] . " -F '#{pane_index}'"), '\n')
+
+  " If we're in the active session & window, filter away current pane from
+  " possibilities
+  let active = <SID>ActiveTarget()
+  let current = [g:tslime['session'], g:tslime['window']]
+  if active[0:1] == current
+    call filter(all_panes, 'v:val != ' . active[2])
+  endif
+  return all_panes
 endfunction
 
 " set tslime.vim variables
@@ -97,11 +110,11 @@ function! s:Tmux_Vars()
 
   let g:tslime['window'] =  substitute(window, ":.*$" , '', 'g')
 
-  let panes = split(s:TmuxPanes(), "\n")
+  let panes = s:TmuxPanes()
   if len(panes) == 1
     let g:tslime['pane'] = panes[0]
   else
-    let g:tslime['pane'] = input("pane number: ", "", "custom,Tmux_Pane_Numbers")
+    let g:tslime['pane'] = input("pane number: ", "", "customlist,Tmux_Pane_Numbers")
     if g:tslime['pane'] == ''
       let g:tslime['pane'] = panes[0]
     endif

--- a/plugin/tslime.vim
+++ b/plugin/tslime.vim
@@ -59,17 +59,26 @@ function! Tmux_Pane_Numbers(A,L,P)
   return <SID>TmuxPanes()
 endfunction
 
-function! s:TmuxSessions()
-  let sessions = system("tmux list-sessions | sed -e 's/:.*$//'")
-  return sessions
-endfunction
-
 function! s:ActiveTarget()
   return split(system('tmux list-panes -F "active=#{pane_active} #{session_name},#{window_index},#{pane_index}" | grep "active=1" | sed -e "s/.*\s//" -e "s/,/\n/g"'), '\n')
 endfunction
 
+function! s:TmuxSessions()
+  if exists("g:tslime_always_current_session") && g:tslime_always_current_session
+    let sessions = <SID>ActiveTarget()[0:0]
+  else
+    let sessions = split(system("tmux list-sessions -F '#{session_name}'"), '\n')
+  endif
+  return sessions
+endfunction
+
 function! s:TmuxWindows()
-  return system('tmux list-windows -t "' . g:tslime['session'] . '" | grep -e "^\w:" | sed -e "s/\s*([0-9].*//g"')
+  if exists("g:tslime_always_current_window") && g:tslime_always_current_window
+    let windows = <SID>ActiveTarget()[1:1]
+  else
+    let windows = split(system('tmux list-windows -F "#{window_index}" -t ' . g:tslime['session']), '\n')
+  endif
+  return windows
 endfunction
 
 function! s:TmuxPanes()
@@ -87,7 +96,7 @@ endfunction
 
 " set tslime.vim variables
 function! s:Tmux_Vars()
-  let names = split(s:TmuxSessions(), "\n")
+  let names = s:TmuxSessions()
   let g:tslime = {}
   if len(names) == 1
     let g:tslime['session'] = names[0]
@@ -95,14 +104,14 @@ function! s:Tmux_Vars()
     let g:tslime['session'] = ''
   endif
   while g:tslime['session'] == ''
-    let g:tslime['session'] = input("session name: ", "", "custom,Tmux_Session_Names")
+    let g:tslime['session'] = input("session name: ", "", "customlist,Tmux_Session_Names")
   endwhile
 
-  let windows = split(s:TmuxWindows(), "\n")
+  let windows = s:TmuxWindows()
   if len(windows) == 1
     let window = windows[0]
   else
-    let window = input("window name: ", "", "custom,Tmux_Window_Names")
+    let window = input("window name: ", "", "customlist,Tmux_Window_Names")
     if window == ''
       let window = windows[0]
     endif

--- a/plugin/tslime.vim
+++ b/plugin/tslime.vim
@@ -60,7 +60,7 @@ function! Tmux_Pane_Numbers(A,L,P)
 endfunction
 
 function! s:ActiveTarget()
-  return split(system('tmux list-panes -F "active=#{pane_active} #{session_name},#{window_index},#{pane_index}" | grep "active=1" | sed -e "s/.*\s//" -e "s/,/\n/g"'), '\n')
+  return split(system('tmux list-panes -F "active=#{pane_active} #{session_name},#{window_index},#{pane_index}" | grep "active=1" | cut -d " " -f 2 | tr , "\n"'), '\n')
 endfunction
 
 function! s:TmuxSessions()


### PR DESCRIPTION
This adds two optional settings:
g:tslime_always_current_session
g:tslime_always_current_session
These will let tslime default to the current (the one with vim in it) session/window, I feel this setting is justified. I think it's a common case to wan't tslime to run in the current window.

A (regarding to me) bugfix is also included, that ensures that the current pane can't be selected, which also makes it faster to use.

I can split these into two PR:s if thats wanted, but I feel they are somewhat related and belongs in the same PR.