### PR TITLE
Fix key mapping in normal mode

### DIFF
--- a/plugin/tslime.vim
+++ b/plugin/tslime.vim
@@ -124,7 +124,7 @@ function! s:Tmux_Vars()
 endfunction
 
 vnoremap <silent> <Plug>SendSelectionToTmux "ry :call Send_to_Tmux(@r)<CR>
-nnoremap <silent> <Plug>NormalModeSendToTmux vip <Plug>SendSelectionToTmux
+nmap     <silent> <Plug>NormalModeSendToTmux vip <Plug>SendSelectionToTmux
 
 nnoremap          <Plug>SetTmuxVars :call <SID>Tmux_Vars()<CR>
 


### PR DESCRIPTION
Can't use `nnoremap` for `<Plug>NormalModeSendToTmux` because it uses
`<Plug>SendSelectionToTmux`