### PR TITLE
Work around unicode mangling in tmux send-keys

### DIFF
--- a/plugin/tslime.vim
+++ b/plugin/tslime.vim
@@ -21,7 +21,12 @@ endfunction
 " Main function.
 " Use it in your script if you want to send text to a tmux session.
 function! Send_to_Tmux(text)
-  call Send_keys_to_Tmux('"'.escape(a:text, '\"$').'"')
+  if !exists("g:tslime")
+    call <SID>Tmux_Vars()
+  endif
+
+  call system("tmux load-buffer -", a:text)
+  call system("tmux paste-buffer -d -t " . s:tmux_target())
 endfunction
 
 function! s:tmux_target()

--- a/plugin/tslime.vim
+++ b/plugin/tslime.vim
@@ -25,8 +25,8 @@ function! Send_to_Tmux(text)
     call <SID>Tmux_Vars()
   endif
 
-  call system("tmux load-buffer -", a:text)
-  call system("tmux paste-buffer -d -t " . s:tmux_target())
+  call system("tmux load-buffer -b tslime -", a:text)
+  call system("tmux paste-buffer -d -b tslime -t " . s:tmux_target())
 endfunction
 
 function! s:tmux_target()


### PR DESCRIPTION
Previously, some characters (e.g., Greek letters) were being sent incorrectly by `Send_to_Tmux`. The cause was tmux's `send-keys` subcommand, which (as of tmux 2.3, on Debian stretch) mangles these characters in transit. Using tmux's `load-buffer` and `paste-buffer` subcommands instead of send-keys allows `Send_to_Tmux` to correctly send these characters.

Test case: `:call Send_to_Tmux("λx.x")`
Result for previous version (c980c76): the string "Î»x.x" is sent to the selected pane.
Result for current version: the string "λx.x" is sent to the selected pane.