### PR TITLE
Ensure trailing newlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,21 @@ let g:tslime_always_current_window = 1
 These are disabled by default, meaning you will have the ability to choose from every 
 session/window/pane combination.
 
+You can also configure tslime.vim to automatically append newlines to the text
+that will be sent to tmux:
+
+    let g:tslime_ensure_trailing_newlines = 1
+
+This is handy when you want to evaluate part of a line as a line of its own,
+or when the REPL you are sending text two requires expressions to be followed
+by a defined number of new lines (eg. Python):
+
+    augroup ft_python
+        au!
+
+        let b:tslime_ensure_trailing_newlines = 2
+    augroup END
+
 Setting Keybindings
 -------------------
 

--- a/plugin/tslime.vim
+++ b/plugin/tslime.vim
@@ -8,6 +8,10 @@ endif
 
 let g:loaded_tslime = 1
 
+if !exists("g:tslime_ensure_trailing_newlines")
+  let g:tslime_ensure_trailing_newlines = 0
+endif
+
 " Function to send keys to tmux
 " useful if you want to stop some command with <c-c> in tmux.
 function! Send_keys_to_Tmux(keys)
@@ -33,7 +37,24 @@ function! s:set_tmux_buffer(text)
   call system("tmux load-buffer -", buf)
 endfunction
 
+function! s:ensure_newlines(text)
+  let text = a:text
+  let trailing_newlines = matchstr(text, '\v\n*$')
+  let spaces_to_add = g:tslime_ensure_trailing_newlines - strlen(trailing_newlines)
+
+  while spaces_to_add > 0
+    let spaces_to_add -= 1
+    let text .= "\n"
+  endwhile
+
+  return text
+endfunction
+
 function! SendToTmux(text)
+  call Send_to_Tmux(s:ensure_newlines(a:text))
+endfunction
+
+function! SendToTmuxRaw(text)
   call Send_to_Tmux(a:text)
 endfunction
 

--- a/plugin/tslime.vim
+++ b/plugin/tslime.vim
@@ -40,7 +40,10 @@ endfunction
 function! s:ensure_newlines(text)
   let text = a:text
   let trailing_newlines = matchstr(text, '\v\n*$')
-  let spaces_to_add = g:tslime_ensure_trailing_newlines - strlen(trailing_newlines)
+  if !exists("b:tslime_ensure_trailing_newlines")
+      let b:tslime_ensure_trailing_newlines = g:tslime_ensure_trailing_newlines
+  endif
+  let spaces_to_add = b:tslime_ensure_trailing_newlines - strlen(trailing_newlines)
 
   while spaces_to_add > 0
     let spaces_to_add -= 1


### PR DESCRIPTION
This PR introduces a new setting, g:tslime_ensure_trailing_newlines, to tell tslime.vim to automatically append as many newlines to the text that will be sent to tmux.

Gently borrowed from: https://github.com/sjl/tslime.vim/commit/5043b1f72ac65d9f4feffe5f465ca2bc6db90256