### PR TITLE
Removes space after paragraph selection in NormalModeSendToTmux

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ Settings
 You can tell tslime.vim to use the current session and current window, this let's you 
 avoid specifying this on every upstart of vim.
 
+```vim
 let g:tslime_always_current_session = 1
 let g:tslime_always_current_window = 1
+```
 
 These are disabled by default, meaning you will have the ability to choose from every 
 session/window/pane combination.

--- a/plugin/tslime.vim
+++ b/plugin/tslime.vim
@@ -124,7 +124,7 @@ function! s:Tmux_Vars()
 endfunction
 
 vnoremap <silent> <Plug>SendSelectionToTmux "ry :call Send_to_Tmux(@r)<CR>
-nmap     <silent> <Plug>NormalModeSendToTmux vip <Plug>SendSelectionToTmux
+nmap     <silent> <Plug>NormalModeSendToTmux vip<Plug>SendSelectionToTmux
 
 nnoremap          <Plug>SetTmuxVars :call <SID>Tmux_Vars()<CR>
 


### PR DESCRIPTION
The single space after `vip` in the `NormalModeSendToTmux` mapping was causing my vim to fold whatever procedure I'm inside. Since I have open/close fold mapped to the spacebar, every time I called this function using `<localleader>n`, it would also end up causing a fold trigger.

Removing the space after `vip` fixed this problem. 

I've also made a minor cosmetic fix to the README.