### PR TITLE
Escape backticks in Send_keys_to_Tmux

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ Settings
 You can tell tslime.vim to use the current session and current window, this let's you 
 avoid specifying this on every upstart of vim.
 
+```vim
 let g:tslime_always_current_session = 1
 let g:tslime_always_current_window = 1
+```
 
 These are disabled by default, meaning you will have the ability to choose from every 
 session/window/pane combination.

--- a/plugin/tslime.vim
+++ b/plugin/tslime.vim
@@ -124,7 +124,7 @@ function! s:Tmux_Vars()
 endfunction
 
 vnoremap <silent> <Plug>SendSelectionToTmux "ry :call Send_to_Tmux(@r)<CR>
-nmap     <silent> <Plug>NormalModeSendToTmux vip <Plug>SendSelectionToTmux
+nmap     <silent> <Plug>NormalModeSendToTmux vip<Plug>SendSelectionToTmux
 
 nnoremap          <Plug>SetTmuxVars :call <SID>Tmux_Vars()<CR>
 

--- a/plugin/tslime.vim
+++ b/plugin/tslime.vim
@@ -21,7 +21,7 @@ endfunction
 " Main function.
 " Use it in your script if you want to send text to a tmux session.
 function! Send_to_Tmux(text)
-  call Send_keys_to_Tmux('"'.escape(a:text, '\"$').'"')
+  call Send_keys_to_Tmux('"'.escape(a:text, '`\"$').'"')
 endfunction
 
 function! s:tmux_target()


### PR DESCRIPTION
## The problem

When writing a lisp variant of code, we use backticks (or quasiquotes) regularly. However, attempting to send them into Tmux causes it to silently fail and not push those changes to the Tmux pane.

## The solution
This PR will also escape backticks being sent to Tmux and allow for backticks! To test: open a Scheme/CL repl in one terminal, try sending this expression to it:
```scheme
`(a b ,(car '(a b c)) ,@(cdr '(1 2 3)))
```

It should silently fail. Now add the changes from this PR, and it should send those changes in fine. This also does not break sending shell commands in the form of double backticks, such as (even tho you shouldn't be doing this):
```
echo `pwd`
```