### PR TITLE
Add tslime_autoset_pane option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Settings
 You can tell tslime.vim to use the current session and current window, this let's you 
 avoid specifying this on every upstart of vim.
 
+Put the following in your `.vimrc` file.
+
 ```vim
 let g:tslime_always_current_session = 1
 let g:tslime_always_current_window = 1
@@ -26,6 +28,13 @@ let g:tslime_always_current_window = 1
 
 These are disabled by default, meaning you will have the ability to choose from every 
 session/window/pane combination.
+
+If you never want to select your pane, but want tslime to automatically send your text to
+the pane in the current window with the largest height, put the following in your `.vimrc`
+
+```vim
+let g:tslime_autoset_pane = 1
+```
 
 Setting Keybindings
 -------------------

--- a/plugin/tslime.vim
+++ b/plugin/tslime.vim
@@ -21,7 +21,7 @@ endfunction
 " Main function.
 " Use it in your script if you want to send text to a tmux session.
 function! Send_to_Tmux(text)
-  if exists("g:tslime_autoset_pane")
+  if exists("g:tslime_autoset_pane") && g:tslime_autoset_pane
     call <SID>Tmux_Vars() 
   endif
   call Send_keys_to_Tmux('"'.escape(a:text, '\"$').'"')
@@ -52,7 +52,7 @@ endfunction
 
 " Pane completion
 function! Tmux_Pane_Numbers(A,L,P)
-  if exists("g:tslime_autoset_pane")
+  if exists("g:tslime_autoset_pane") && g:tslime_autoset_pane
     return <SID>AutoTmuxPanes()
   else
     return <SID>TmuxPanes()
@@ -145,7 +145,7 @@ function! s:Tmux_Vars()
 
   let g:tslime['window'] =  substitute(window, ":.*$" , '', 'g')
 
-  if exists("g:tslime_autoset_pane")
+  if exists("g:tslime_autoset_pane") && g:tslime_autoset_pane
     let panes = s:AutoTmuxPanes()
   else
     let panes = s:TmuxPanes()

--- a/plugin/tslime.vim
+++ b/plugin/tslime.vim
@@ -21,6 +21,9 @@ endfunction
 " Main function.
 " Use it in your script if you want to send text to a tmux session.
 function! Send_to_Tmux(text)
+  if exists("g:tslime_autoset_pane")
+    call <SID>Tmux_Vars() 
+  endif
   call Send_keys_to_Tmux('"'.escape(a:text, '\"$').'"')
 endfunction
 
@@ -49,7 +52,11 @@ endfunction
 
 " Pane completion
 function! Tmux_Pane_Numbers(A,L,P)
-  return <SID>TmuxPanes()
+  if exists("g:tslime_autoset_pane")
+    return <SID>AutoTmuxPanes()
+  else
+    return <SID>TmuxPanes()
+  endif
 endfunction
 
 function! s:ActiveTarget()
@@ -87,6 +94,32 @@ function! s:TmuxPanes()
   return all_panes
 endfunction
 
+function! s:AutoTmuxPanes()
+  let valid_panes = {}
+  let pane_heights = split(system('tmux list-panes -t "' . g:tslime['session'] . '":' . g:tslime['window'] . " -F '#{pane_height}'"), '\n')
+  let c = 0
+  for heights in pane_heights
+    let valid_panes[c] = str2nr(heights)
+    let c += 1 
+  endfor
+  " If we're in the active session & window, filter away current pane from
+  " possibilities
+  let active = <SID>ActiveTarget()
+  let current = [g:tslime['session'], g:tslime['window']]
+  if active[0:1] == current
+    call remove(valid_panes, active[2])
+  endif
+  " have to do this loop because max(valid_panes) doesn't work
+  let biggest_height = 0
+  for [index, height] in items(valid_panes)
+    if height >= biggest_height
+      let biggest_height = height
+      let biggest_pane = index
+    endif
+  endfor
+  return [biggest_pane]
+endfunction
+
 " set tslime.vim variables
 function! s:Tmux_Vars()
   let names = s:TmuxSessions()
@@ -112,7 +145,12 @@ function! s:Tmux_Vars()
 
   let g:tslime['window'] =  substitute(window, ":.*$" , '', 'g')
 
-  let panes = s:TmuxPanes()
+  if exists("g:tslime_autoset_pane")
+    let panes = s:AutoTmuxPanes()
+  else
+    let panes = s:TmuxPanes()
+  endif
+
   if len(panes) == 1
     let g:tslime['pane'] = panes[0]
   else
@@ -129,3 +167,4 @@ nmap     <silent> <Plug>NormalModeSendToTmux vip<Plug>SendSelectionToTmux
 nnoremap          <Plug>SetTmuxVars :call <SID>Tmux_Vars()<CR>
 
 command! -nargs=* Tmux call Send_to_Tmux('<Args><CR>')
+


### PR DESCRIPTION
(Duplicate of https://github.com/jgdavey/tslime.vim/pull/25 since it was accidentally closed)

Never manually select a pane again!

This option automatically chooses the tallest pane in the same window (that is not currently active) and sets this as the target pane.

![tslime_demo](https://user-images.githubusercontent.com/4926143/40591141-87d6615c-61d9-11e8-8c35-daa34e701ef8.gif)