### PR TITLE
escape backticks character

### DIFF
--- a/plugin/tslime.vim
+++ b/plugin/tslime.vim
@@ -24,7 +24,7 @@ function! Send_to_Tmux(text)
   if exists("g:tslime_autoset_pane") && g:tslime_autoset_pane
     call <SID>Tmux_Vars() 
   endif
-  call Send_keys_to_Tmux('"'.escape(a:text, '\"$').'"')
+  call Send_keys_to_Tmux('"'.escape(a:text, '\"$`').'"')
 endfunction
 
 function! s:tmux_target()


### PR DESCRIPTION
backticks (`) is part of the ES2015 template string syntax
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals

so need to escape (`) as well, otherwise tmux considers it a command and the template string is lost